### PR TITLE
[INJICERT-323]

### DIFF
--- a/mock-certify-plugin/pom.xml
+++ b/mock-certify-plugin/pom.xml
@@ -52,6 +52,7 @@
         <git-commit-id-plugin.version>3.0.1</git-commit-id-plugin.version>
         <maven.jacoco.version>0.8.11</maven.jacoco.version>
         <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
+        <kernel-keymanager-service.version>1.3.0-SNAPSHOT</kernel-keymanager-service.version>
     </properties>
     <dependencies>
 
@@ -95,7 +96,7 @@
         <dependency>
             <groupId>io.mosip.kernel</groupId>
             <artifactId>kernel-keymanager-service</artifactId>
-            <version>1.2.1-java21-SNAPSHOT</version>
+            <version>${kernel-keymanager-service.version}</version>
             <scope>provided</scope>
             <classifier>lib</classifier>
             <exclusions>

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -83,7 +83,7 @@
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven.jacoco.version>0.8.11</maven.jacoco.version>
         <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
-        <kernel-keymanager-service.version>1.2.1-java21-SNAPSHOT</kernel-keymanager-service.version>
+        <kernel-keymanager-service.version>1.3.0-SNAPSHOT</kernel-keymanager-service.version>
         <jackson.version>2.12.1</jackson.version>
 
     </properties>


### PR DESCRIPTION
Updated Kernel Keymanager to 1.3.0-SNAPSHOT in Digital Credentials Plugin Modules
 1. mock-certify-plugin
 2. mock-inditity-certify-plugin