### PR TITLE
[INJICERT-695] handle null data when creating mdoc data entry

### DIFF
--- a/mock-certify-plugin/src/main/java/io/mosip/certify/mock/integration/mocks/MdocGenerator.java
+++ b/mock-certify-plugin/src/main/java/io/mosip/certify/mock/integration/mocks/MdocGenerator.java
@@ -68,7 +68,7 @@ public class MdocGenerator {
         drivingPrivileges.put("issue_date", formattedIssueDate);
         drivingPrivileges.put("expiry_date", formattedExpiryDate);
 
-        data.keySet().forEach(key -> nameSpacedDataBuilder.putEntryString(NAMESPACE, key, data.get(key).toString()));
+        data.keySet().forEach(key -> nameSpacedDataBuilder.putEntryString(NAMESPACE, key, Objects.toString(data.get(key),"")));
 
         NameSpacedData nameSpacedData = nameSpacedDataBuilder.build();
         Map<String, List<byte[]>> generatedIssuerNameSpaces = MdocUtil.generateIssuerNameSpaces(nameSpacedData, new Random(SEED), 16);


### PR DESCRIPTION
This change is being made because in case of IndividualId not stored, documentNumber value becomes null and credential generation fails while creating the mdoc due to NullPointer exception. 

Note: In case of IndividualId not stored, documentNumber in the mdoc will be empty string ("")

```
"elementIdentifier": "document_number",
"elementValue": ""
```