### PR TITLE
[INJICERT-695] update note in mdoc secret creation script

### DIFF
--- a/mock-certify-plugin/README.md
+++ b/mock-certify-plugin/README.md
@@ -67,7 +67,9 @@ generate_keys() {
     echo "Encoding the certificate to Base64..."
     base64EncodedCertificate=$(base64 -i $CERTIFICATE_FILE)
 
-    echo "------Base64 Encoded key||Certificate:"
+    echo "Secret created successfully..."
+    echo "Adding the contents into a file"
+    echo "Note: Make sure to add the generated secret without any newlines in the value, as new lines presence would cause issues when service loads the secret"
     echo -n "$base64EncodedPrivateKey||$base64EncodedCertificate" > issuerSecret.txt
 
     echo "------------------------------------------------------------------------------"


### PR DESCRIPTION
secret creation script uses echo command to add secret into a file, this in OS like windows creates multi line secret which is not expected. Added note reg new lines issue in script