### PR TITLE
[INJICERT-981] Add MockMDocDataProviderPlugin for mDL credential data provision

### DIFF
--- a/mock-certify-plugin/README.md
+++ b/mock-certify-plugin/README.md
@@ -6,6 +6,7 @@ The Mock Certify Plugin is a combination implementation of three plugins.
 2. MockCSVDataProviderPlugin - A CSV plugin which exposes data based on some valid claims, it is a small plugin which enables teams to get a headstart for generating VC credentials of any type. It returns the user data, which can be used by the Issuer to generate a VC.
 3. MDocMockVCIssuancePlugin - A Mock-Driving license plugin which returns a Mock "Mobile Driving License"(mDL) with some hardcoded data, it returns the VC in an [mDoc format](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-13.html#name-iso-mdl).
 
+4. MockMDocDataProviderPlugin - A mock data provider plugin that returns claim data formatted for mDL issuance. It injects metadata such as `_issuedAt`, `_validUntil`, `_issuer`, and `_docType`. Works in tandem with `MDocMockVCIssuancePlugin`.
 
 ## Configuration Options
 
@@ -115,3 +116,20 @@ mosip.certify.mock.data-provider.csv.identifier-column=
 mosip.certify.mock.data-provider.csv.data-columns=
 ```
 
+### MockMDocDataProviderPlugin
+
+To use this plugin set the below properties
+
+```properties
+mosip.certify.integration.data-provider-plugin=MockMDocDataProviderPlugin
+mosip.certify.mock.data-provider.mdoc.issuer-id=https://example-issuer.org
+mosip.certify.mock.data-provider.mdoc.default-doctype=org.iso.18013.5.1.mDL
+mosip.certify.mock.data-provider.mdoc.validity-days=365
+```
+
+This plugin automatically constructs mock claim data based on incoming `identityDetails`, populates metadata such as:
+
+* `_issuer` – The Issuer ID (`issuer-id`)
+* `_docType` – Document Type (`default-doctype`)
+* `_issuedAt` – Current UTC Timestamp
+* `_validUntil` – UTC Timestamp + `validity-days`

--- a/mock-certify-plugin/src/main/java/io.mosip.certify.mock.integration/service/MockMDocDataProviderPlugin.java
+++ b/mock-certify-plugin/src/main/java/io.mosip.certify.mock.integration/service/MockMDocDataProviderPlugin.java
@@ -1,0 +1,77 @@
+package io.mosip.certify.mock.integration.service;
+
+import io.mosip.certify.api.exception.DataProviderExchangeException;
+import io.mosip.certify.api.spi.DataProviderPlugin;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+@ConditionalOnProperty(
+        value = "mosip.certify.integration.data-provider-plugin",
+        havingValue = "MockMDocDataProviderPlugin"
+)
+@Component
+@Slf4j
+public class MockMDocDataProviderPlugin implements DataProviderPlugin {
+
+    @Value("${mosip.certify.mock.data-provider.mdoc.issuer-id:https://example-issuer.org}")
+    private String issuer;
+
+    @Value("${mosip.certify.mock.data-provider.mdoc.default-doctype:org.iso.18013.5.1.mDL}")
+    private String defaultDocType;
+
+    @Value("${mosip.certify.mock.data-provider.mdoc.validity-days:365}")
+    private long validityDays;
+
+    @PostConstruct
+    public void init() {
+        log.info("MockMDocDataProviderPlugin initialized with issuer: {}, defaultDocType: {}, validityDays: {}",
+                issuer, defaultDocType, validityDays);
+    }
+
+    @Override
+    public JSONObject fetchData(Map<String, Object> identityDetails) throws DataProviderExchangeException {
+        try {
+            if (identityDetails == null || identityDetails.isEmpty()) {
+                throw new DataProviderExchangeException("No identity data provided.");
+            }
+
+            Map<String, Object> claims = (Map<String, Object>) identityDetails.get("claims");
+
+            if (claims == null || claims.isEmpty()) {
+                throw new DataProviderExchangeException("Claims section is missing or empty.");
+            }
+
+            // Take the first (and assumed only) namespace in claims
+            String namespace = claims.keySet().iterator().next();
+
+            Map<String, Object> namespaceClaims = (Map<String, Object>) claims.get(namespace);
+
+            if (namespaceClaims == null || namespaceClaims.isEmpty()) {
+                throw new DataProviderExchangeException("No claim data found under namespace: " + namespace);
+            }
+
+            JSONObject claimData = new JSONObject(namespaceClaims);
+
+            // Add system metadata
+            claimData.put("_docType", identityDetails.getOrDefault("doctype", defaultDocType));
+            claimData.put("_issuer", issuer);
+            claimData.put("_issuedAt", Instant.now().toString());
+            claimData.put("_validUntil", Instant.now().plus(validityDays, ChronoUnit.DAYS).toString());
+
+            log.debug("Returning mdoc claim data with system metadata: {}", claimData.toString(2));
+            return claimData;
+
+        } catch (Exception e) {
+            log.error("Failed to process mdoc data in MockMDocDataProviderPlugin", e);
+            throw new DataProviderExchangeException("ERROR_PROCESSING_MDOC_DATA: " + e);
+        }
+    }
+}

--- a/mock-certify-plugin/src/main/java/io.mosip.certify.mock.integration/service/MockMDocDataProviderPlugin.java
+++ b/mock-certify-plugin/src/main/java/io.mosip.certify.mock.integration/service/MockMDocDataProviderPlugin.java
@@ -69,9 +69,11 @@ public class MockMDocDataProviderPlugin implements DataProviderPlugin {
             log.debug("Returning mdoc claim data with system metadata: {}", claimData.toString(2));
             return claimData;
 
+        } catch (DataProviderExchangeException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Failed to process mdoc data in MockMDocDataProviderPlugin", e);
-            throw new DataProviderExchangeException("ERROR_PROCESSING_MDOC_DATA: " + e);
+            throw new DataProviderExchangeException("ERROR_PROCESSING_MDOC_DATA: " + e.getMessage());
         }
     }
 }

--- a/mock-certify-plugin/src/test/java/io/mosip/certify/mock/integration/service/MockMDocDataProviderPluginTest.java
+++ b/mock-certify-plugin/src/test/java/io/mosip/certify/mock/integration/service/MockMDocDataProviderPluginTest.java
@@ -1,0 +1,287 @@
+package io.mosip.certify.mock.integration.service;
+
+import io.mosip.certify.api.exception.DataProviderExchangeException;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MockMDocDataProviderPluginTest {
+
+    @InjectMocks
+    MockMDocDataProviderPlugin mockMDocDataProviderPlugin = new MockMDocDataProviderPlugin();
+
+    @Before
+    public void setup() {
+        ReflectionTestUtils.setField(mockMDocDataProviderPlugin, "issuer", "https://test-issuer.org");
+        ReflectionTestUtils.setField(mockMDocDataProviderPlugin, "defaultDocType", "org.iso.18013.5.1.mDL");
+        ReflectionTestUtils.setField(mockMDocDataProviderPlugin, "validityDays", 365L);
+    }
+
+    @Test
+    public void fetchData_withValidIdentityDetails_thenPass() throws DataProviderExchangeException, JSONException {
+        // Arrange
+        Map<String, Object> identityDetails = new HashMap<>();
+        identityDetails.put("doctype", "org.iso.18013.5.1.mDL");
+
+        Map<String, Object> claims = new HashMap<>();
+        Map<String, Object> namespaceClaims = new HashMap<>();
+        namespaceClaims.put("given_name", "John");
+        namespaceClaims.put("family_name", "Doe");
+        namespaceClaims.put("birth_date", "1990-01-01");
+        namespaceClaims.put("document_number", "DL123456789");
+
+        claims.put("org.iso.18013.5.1", namespaceClaims);
+        identityDetails.put("claims", claims);
+
+        // Act
+        JSONObject result = mockMDocDataProviderPlugin.fetchData(identityDetails);
+
+        // Assert
+        Assert.assertNotNull(result);
+        Assert.assertEquals("John", result.get("given_name"));
+        Assert.assertEquals("Doe", result.get("family_name"));
+        Assert.assertEquals("1990-01-01", result.get("birth_date"));
+        Assert.assertEquals("DL123456789", result.get("document_number"));
+
+        // Verify system metadata
+        Assert.assertEquals("org.iso.18013.5.1.mDL", result.get("_docType"));
+        Assert.assertEquals("https://test-issuer.org", result.get("_issuer"));
+        Assert.assertNotNull(result.get("_issuedAt"));
+        Assert.assertNotNull(result.get("_validUntil"));
+    }
+
+    @Test
+    public void fetchData_withDefaultDocType_thenPass() throws DataProviderExchangeException, JSONException {
+        // Arrange
+        Map<String, Object> identityDetails = new HashMap<>();
+
+        Map<String, Object> claims = new HashMap<>();
+        Map<String, Object> namespaceClaims = new HashMap<>();
+        namespaceClaims.put("given_name", "Jane");
+        namespaceClaims.put("family_name", "Smith");
+
+        claims.put("org.iso.18013.5.1", namespaceClaims);
+        identityDetails.put("claims", claims);
+
+        // Act
+        JSONObject result = mockMDocDataProviderPlugin.fetchData(identityDetails);
+
+        // Assert
+        Assert.assertNotNull(result);
+        Assert.assertEquals("Jane", result.get("given_name"));
+        Assert.assertEquals("Smith", result.get("family_name"));
+        Assert.assertEquals("org.iso.18013.5.1.mDL", result.get("_docType")); // Should use default
+    }
+
+    @Test
+    public void fetchData_withNullIdentityDetails_thenFail() {
+        // Act & Assert
+        try {
+            mockMDocDataProviderPlugin.fetchData(null);
+            Assert.fail("Expected DataProviderExchangeException");
+        } catch (DataProviderExchangeException e) {
+            Assert.assertEquals("No identity data provided.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void fetchData_withEmptyIdentityDetails_thenFail() {
+        // Act & Assert
+        try {
+            mockMDocDataProviderPlugin.fetchData(new HashMap<>());
+            Assert.fail("Expected DataProviderExchangeException");
+        } catch (DataProviderExchangeException e) {
+            Assert.assertEquals("No identity data provided.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void fetchData_withMissingClaims_thenFail() {
+        // Arrange
+        Map<String, Object> identityDetails = new HashMap<>();
+        identityDetails.put("doctype", "org.iso.18013.5.1.mDL");
+
+        // Act & Assert
+        try {
+            mockMDocDataProviderPlugin.fetchData(identityDetails);
+            Assert.fail("Expected DataProviderExchangeException");
+        } catch (DataProviderExchangeException e) {
+            Assert.assertEquals("Claims section is missing or empty.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void fetchData_withEmptyClaims_thenFail() {
+        // Arrange
+        Map<String, Object> identityDetails = new HashMap<>();
+        identityDetails.put("doctype", "org.iso.18013.5.1.mDL");
+        identityDetails.put("claims", new HashMap<>());
+
+        // Act & Assert
+        try {
+            mockMDocDataProviderPlugin.fetchData(identityDetails);
+            Assert.fail("Expected DataProviderExchangeException");
+        } catch (DataProviderExchangeException e) {
+            Assert.assertEquals("Claims section is missing or empty.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void fetchData_withEmptyNamespaceClaims_thenFail() {
+        // Arrange
+        Map<String, Object> identityDetails = new HashMap<>();
+        identityDetails.put("doctype", "org.iso.18013.5.1.mDL");
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("org.iso.18013.5.1", new HashMap<>());
+        identityDetails.put("claims", claims);
+
+        // Act & Assert
+        try {
+            mockMDocDataProviderPlugin.fetchData(identityDetails);
+            Assert.fail("Expected DataProviderExchangeException");
+        } catch (DataProviderExchangeException e) {
+            Assert.assertTrue(e.getMessage().contains("No claim data found under namespace"));
+        }
+    }
+
+    @Test
+    public void fetchData_withNullNamespaceClaims_thenFail() {
+        // Arrange
+        Map<String, Object> identityDetails = new HashMap<>();
+        identityDetails.put("doctype", "org.iso.18013.5.1.mDL");
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("org.iso.18013.5.1", null);
+        identityDetails.put("claims", claims);
+
+        // Act & Assert
+        try {
+            mockMDocDataProviderPlugin.fetchData(identityDetails);
+            Assert.fail("Expected DataProviderExchangeException");
+        } catch (DataProviderExchangeException e) {
+            Assert.assertTrue(e.getMessage().contains("No claim data found under namespace"));
+        }
+    }
+
+    @Test
+    public void fetchData_withMultipleNamespaces_shouldUseFirst() throws DataProviderExchangeException, JSONException {
+        // Arrange
+        Map<String, Object> identityDetails = new HashMap<>();
+        identityDetails.put("doctype", "org.iso.18013.5.1.mDL");
+
+        Map<String, Object> claims = new HashMap<>();
+
+        // First namespace
+        Map<String, Object> firstNamespaceClaims = new HashMap<>();
+        firstNamespaceClaims.put("given_name", "John");
+        firstNamespaceClaims.put("family_name", "Doe");
+        claims.put("org.iso.18013.5.1", firstNamespaceClaims);
+
+        // Second namespace
+        Map<String, Object> secondNamespaceClaims = new HashMap<>();
+        secondNamespaceClaims.put("given_name", "Jane");
+        secondNamespaceClaims.put("family_name", "Smith");
+        claims.put("com.example.another", secondNamespaceClaims);
+
+        identityDetails.put("claims", claims);
+
+        // Act
+        JSONObject result = mockMDocDataProviderPlugin.fetchData(identityDetails);
+
+        // Assert
+        Assert.assertNotNull(result);
+        // Should use the first namespace data (order depends on HashMap iteration, but we expect consistent behavior)
+        Assert.assertTrue(result.has("given_name"));
+        Assert.assertTrue(result.has("family_name"));
+    }
+
+    @Test
+    public void fetchData_withCustomValidityDays() throws DataProviderExchangeException, JSONException {
+        // Arrange
+        ReflectionTestUtils.setField(mockMDocDataProviderPlugin, "validityDays", 180L);
+
+        Map<String, Object> identityDetails = new HashMap<>();
+        identityDetails.put("doctype", "org.iso.18013.5.1.mDL");
+
+        Map<String, Object> claims = new HashMap<>();
+        Map<String, Object> namespaceClaims = new HashMap<>();
+        namespaceClaims.put("given_name", "John");
+
+        claims.put("org.iso.18013.5.1", namespaceClaims);
+        identityDetails.put("claims", claims);
+
+        // Act
+        JSONObject result = mockMDocDataProviderPlugin.fetchData(identityDetails);
+
+        // Assert
+        Assert.assertNotNull(result);
+
+        String issuedAtStr = result.getString("_issuedAt");
+        String validUntilStr = result.getString("_validUntil");
+
+        Instant issuedAt = Instant.parse(issuedAtStr);
+        Instant validUntil = Instant.parse(validUntilStr);
+
+        // Verify validUntil is 180 days after issuedAt
+        Instant expectedValidUntil = issuedAt.plus(180, ChronoUnit.DAYS);
+        Assert.assertEquals(expectedValidUntil, validUntil);
+    }
+
+    @Test
+    public void fetchData_withComplexClaimData() throws DataProviderExchangeException, JSONException {
+        // Arrange
+        Map<String, Object> identityDetails = new HashMap<>();
+        identityDetails.put("doctype", "org.iso.18013.5.1.mDL");
+
+        Map<String, Object> claims = new HashMap<>();
+        Map<String, Object> namespaceClaims = new HashMap<>();
+        namespaceClaims.put("given_name", "John");
+        namespaceClaims.put("family_name", "Doe");
+        namespaceClaims.put("birth_date", "1990-01-01");
+        namespaceClaims.put("issue_date", "2023-01-01");
+        namespaceClaims.put("expiry_date", "2028-01-01");
+        namespaceClaims.put("issuing_country", "US");
+        namespaceClaims.put("issuing_authority", "DMV");
+        namespaceClaims.put("document_number", "DL123456789");
+        namespaceClaims.put("portrait", "base64encodedimage");
+
+        claims.put("org.iso.18013.5.1", namespaceClaims);
+        identityDetails.put("claims", claims);
+
+        // Act
+        JSONObject result = mockMDocDataProviderPlugin.fetchData(identityDetails);
+
+        // Assert
+        Assert.assertNotNull(result);
+        Assert.assertEquals("John", result.get("given_name"));
+        Assert.assertEquals("Doe", result.get("family_name"));
+        Assert.assertEquals("1990-01-01", result.get("birth_date"));
+        Assert.assertEquals("2023-01-01", result.get("issue_date"));
+        Assert.assertEquals("2028-01-01", result.get("expiry_date"));
+        Assert.assertEquals("US", result.get("issuing_country"));
+        Assert.assertEquals("DMV", result.get("issuing_authority"));
+        Assert.assertEquals("DL123456789", result.get("document_number"));
+        Assert.assertEquals("base64encodedimage", result.get("portrait"));
+
+        // Verify system metadata
+        Assert.assertEquals("org.iso.18013.5.1.mDL", result.get("_docType"));
+        Assert.assertEquals("https://test-issuer.org", result.get("_issuer"));
+        Assert.assertNotNull(result.get("_issuedAt"));
+        Assert.assertNotNull(result.get("_validUntil"));
+    }
+}


### PR DESCRIPTION
This PR introduces the MockMDocDataProviderPlugin, a new data provider plugin specifically designed for mDoc credential issuance.

## Changes Made:
- **New Plugin**: Added `MockMDocDataProviderPlugin.java` that implements the `DataProviderPlugin` interface
- **Documentation**: Updated README.md with configuration details and usage instructions

## Key Features:
- **Metadata Injection**: Automatically adds system metadata including:
  - `_issuer` - Configurable issuer ID
  - `_docType` - Document type (defaults to `org.iso.18013.5.1.mDL`)  
  - `_issuedAt` - Current UTC timestamp
  - `_validUntil` - Expiry timestamp based on configurable validity period

- **Configurable Properties**:
  - `mosip.certify.mock.data-provider.mdoc.issuer-id`
  - `mosip.certify.mock.data-provider.mdoc.default-doctype`
  - `mosip.certify.mock.data-provider.mdoc.validity-days`

- **Integration**: Works seamlessly with `MDocMockVCIssuancePlugin` for complete mDL credential workflow

## Usage:
Enable the plugin by setting:
```properties
mosip.certify.integration.data-provider-plugin=MockMDocDataProviderPlugin