### PR TITLE
[INJICERT-1298] Update groupId to publish certify plugins to new group io.inji

### DIFF
--- a/mock-certify-plugin/pom.xml
+++ b/mock-certify-plugin/pom.xml
@@ -8,14 +8,14 @@
 
       <modelVersion>4.0.0</modelVersion>
 
-      <groupId>io.mosip.certify</groupId>
+      <groupId>io.inji.certify</groupId>
       <artifactId>mock-certify-plugin</artifactId>
       <version>0.5.0-SNAPSHOT</version>
       <packaging>jar</packaging>
 
       <name>mock-certify-integration-impl</name>
       <description>Mockup of a wrapper implementation that is used to showcase the integration with certify</description>
-      <url>https://github.com/mosip/digital-credential-plugins</url>
+      <url>https://github.com/inji/digital-credential-plugins</url>
 
       <licenses>
           <license>
@@ -26,15 +26,15 @@
       <scm>
           <connection>scm:git:git://github.com/mosip/digital-credential-plugins.git</connection>
           <developerConnection>scm:git:ssh://github.com:mosip/digital-credential-plugins.git</developerConnection>
-          <url>https://github.com/mosip/digital-credential-plugins</url>
+          <url>https://github.com/inji/digital-credential-plugins</url>
           <tag>HEAD</tag>
       </scm>
       <developers>
         <developer>
             <name>Mosip</name>
             <email>mosip.emailnotifier@gmail.com</email>
-            <organization>io.mosip</organization>
-            <organizationUrl>https://www.mosip.io</organizationUrl>
+            <organization>io.inji</organization>
+            <organizationUrl>https://inji.io</organizationUrl>
         </developer>
       </developers>
 

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -6,14 +6,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.mosip.certify</groupId>
+    <groupId>io.inji.certify</groupId>
     <artifactId>mosip-identity-certify-plugin</artifactId>
     <version>0.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>mosipid-certify-integration-impl</name>
     <description>MOSIP-ID plugin implementation that is used for the integration with certify</description>
-    <url>https://github.com/mosip/digital-credential-plugins</url>
+    <url>https://github.com/inji/digital-credential-plugins</url>
 
     <licenses>
         <license>
@@ -24,15 +24,15 @@
     <scm>
         <connection>scm:git:git://github.com/mosip/digital-credential-plugins.git</connection>
         <developerConnection>scm:git:ssh://github.com:mosip/digital-credential-plugins.git</developerConnection>
-        <url>https://github.com/mosip/digital-credential-plugins</url>
+        <url>https://github.com/inji/digital-credential-plugins</url>
         <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>
             <name>Mosip</name>
             <email>mosip.emailnotifier@gmail.com</email>
-            <organization>io.mosip</organization>
-            <organizationUrl>https://www.mosip.io</organizationUrl>
+            <organization>io.inji</organization>
+            <organizationUrl>https://inji.io</organizationUrl>
         </developer>
     </developers>
 

--- a/postgres-dataprovider-plugin/pom.xml
+++ b/postgres-dataprovider-plugin/pom.xml
@@ -2,14 +2,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.mosip.certify</groupId>
+    <groupId>io.inji.certify</groupId>
     <artifactId>postgres-dataprovider-plugin</artifactId>
     <version>0.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>postgres-dataprovider-plugin</name>
     <description>Data provider plugin implementation through postgres db that is used to showcase the integration with certify</description>
-    <url>https://github.com/mosip/digital-credential-plugins</url>
+    <url>https://github.com/inji/digital-credential-plugins</url>
 
     <licenses>
         <license>
@@ -20,15 +20,15 @@
     <scm>
         <connection>scm:git:git://github.com/mosip/digital-credential-plugins.git</connection>
         <developerConnection>scm:git:ssh://github.com:mosip/digital-credential-plugins.git</developerConnection>
-        <url>https://github.com/mosip/digital-credential-plugins</url>
+        <url>https://github.com/inji/digital-credential-plugins</url>
         <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>
             <name>MOSIP</name>
             <email>mosip.emailnotifier@gmail.com</email>
-            <organization>io.mosip</organization>
-            <organizationUrl>https://www.mosip.io</organizationUrl>
+            <organization>io.inji</organization>
+            <organizationUrl>https://inji.io</organizationUrl>
         </developer>
     </developers>
 

--- a/sunbird-rc-certify-integration-impl/pom.xml
+++ b/sunbird-rc-certify-integration-impl/pom.xml
@@ -6,14 +6,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.mosip.certify.sunbirdrc</groupId>
+    <groupId>io.inji.certify.sunbirdrc</groupId>
     <artifactId>sunbird-rc-certify-integration-impl</artifactId>
     <version>0.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sunbird-rc-certify-integration-impl</name>
     <description>Sunbird-RC plugin implementation that is used for the integration with certify</description>
-    <url>https://github.com/mosip/digital-credential-plugins</url>
+    <url>https://github.com/inji/digital-credential-plugins</url>
 
     <licenses>
         <license>
@@ -24,15 +24,15 @@
     <scm>
         <connection>scm:git:git://github.com/mosip/digital-credential-plugins.git</connection>
         <developerConnection>scm:git:ssh://github.com:mosip/digital-credential-plugins.git</developerConnection>
-        <url>https://github.com/mosip/digital-credential-plugins</url>
+        <url>https://github.com/inji/digital-credential-plugins</url>
         <tag>HEAD</tag>
     </scm>
     <developers>
         <developer>
             <name>Mosip</name>
             <email>mosip.emailnotifier@gmail.com</email>
-            <organization>io.mosip</organization>
-            <organizationUrl>https://www.mosip.io</organizationUrl>
+            <organization>io.inji</organization>
+            <organizationUrl>https://inji.io</organizationUrl>
         </developer>
     </developers>
     <properties>

--- a/sunbird-rc-esignet-integration-impl/pom.xml
+++ b/sunbird-rc-esignet-integration-impl/pom.xml
@@ -9,7 +9,7 @@
 	
 	<name>sunbird-rc-esignet-integration-impl</name>
 	<description>Sunbird-RC plugin implementation that is used for the integration with eSignet</description>
-	<url>https://github.com/mosip/digital-credential-plugins</url>
+	<url>https://github.com/inji/digital-credential-plugins</url>
 	
 	<licenses>
 		<license>
@@ -20,7 +20,7 @@
 	<scm>
 		<connection>scm:git:git://github.com/mosip/digital-credential-plugins.git</connection>
 		<developerConnection>scm:git:ssh://github.com:mosip/digital-credential-plugins.git</developerConnection>
-		<url>https://github.com/mosip/digital-credential-plugins</url>
+		<url>https://github.com/inji/digital-credential-plugins</url>
 		<tag>HEAD</tag>
 	</scm>
 	<developers>
@@ -28,7 +28,7 @@
 			<name>Mosip</name>
 			<email>mosip.emailnotifier@gmail.com</email>
 			<organization>io.mosip</organization>
-			<organizationUrl>https://github.com/mosip/digital-credential-plugins</organizationUrl>
+			<organizationUrl>https://www.mosip.io</organizationUrl>
 		</developer>
 	</developers>
 	<properties>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project group and organization identifiers across multiple modules.
  * Updated public project URLs and source-repository (SCM) references to the new repository location, and adjusted organization display URLs in developer metadata.
  * These updates refresh public-facing project metadata used in listings, packaging, and repository references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->