### PR TITLE
[INJICERT-1295] Update mosipid from vcissuance to data provider plugin

### DIFF
--- a/mock-certify-plugin/pom.xml
+++ b/mock-certify-plugin/pom.xml
@@ -10,7 +10,7 @@
 
       <groupId>io.inji.certify</groupId>
       <artifactId>mock-certify-plugin</artifactId>
-      <version>0.5.0-SNAPSHOT</version>
+      <version>0.6.0-SNAPSHOT</version>
       <packaging>jar</packaging>
 
       <name>mock-certify-integration-impl</name>
@@ -65,13 +65,13 @@
         <dependency>
             <groupId>io.mosip.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>0.12.0-SNAPSHOT</version>
+            <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.mosip.esignet</groupId>
             <artifactId>esignet-core</artifactId>
-            <version>1.5.1</version>
+            <version>1.6.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.mosip.esignet</groupId>
             <artifactId>esignet-integration-api</artifactId>
-            <version>1.5.1</version>
+            <version>1.6.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/mock-certify-plugin/pom.xml
+++ b/mock-certify-plugin/pom.xml
@@ -63,7 +63,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.mosip.certify</groupId>
+            <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
             <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji.certify</groupId>
     <artifactId>mosip-identity-certify-plugin</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>mosipid-certify-integration-impl</name>
@@ -98,13 +98,13 @@
         <dependency>
             <groupId>io.mosip.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>0.12.0-SNAPSHOT</version>
+            <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.mosip.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
-            <version>0.12.0-SNAPSHOT</version>
+            <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -146,7 +146,7 @@
             <groupId>io.mosip.esignet</groupId>
             <artifactId>esignet-core</artifactId>
 
-            <version>1.5.1</version>
+            <version>1.6.2</version>
            <exclusions>
                <exclusion>
                    <groupId>*</groupId>
@@ -157,13 +157,18 @@
         <dependency>
             <groupId>io.mosip.esignet</groupId>
             <artifactId>esignet-integration-api</artifactId>
-            <version>1.5.1</version>
+            <version>1.6.2</version>
            <exclusions>
                <exclusion>
                    <groupId>*</groupId>
                    <artifactId>*</artifactId>
                </exclusion>
            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.15.4</version>
         </dependency>
     </dependencies>
 

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -96,13 +96,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.mosip.certify</groupId>
+            <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
             <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.mosip.certify</groupId>
+            <groupId>io.inji.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
             <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/dto/IdaKycExchangeRequest.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/dto/IdaKycExchangeRequest.java
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package io.mosip.certify.mosipid.integration.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IdaKycExchangeRequest {
+
+    private String id;
+    private String version;
+    private String requestTime;
+    private String transactionID;
+    private String kycToken;
+    private List<String> consentObtained;
+    private List<String> locales;
+    private String respType;
+    private String individualId;
+
+    /**
+     * claims metadata - Not set/un used for now from IDA
+     */
+    private Map<String, Object> metadata;
+    /**
+     * User consented verified claims list.
+     */
+    List<Map<String, Object>> verifiedConsentedClaims;
+    /**
+     * User consented unverified claims list.
+     */
+    Map<String, Object> unVerifiedConsentedClaims;
+
+}

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/dto/IdaKycExchangeResponse.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/dto/IdaKycExchangeResponse.java
@@ -1,0 +1,14 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package io.mosip.certify.mosipid.integration.dto;
+
+import lombok.Data;
+
+@Data
+public class IdaKycExchangeResponse {
+
+    private String encryptedKyc;
+}

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/AuthTransactionHelper.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/AuthTransactionHelper.java
@@ -27,7 +27,7 @@ import java.time.LocalDateTime;
 
 @Component
 @Slf4j
-@ConditionalOnProperty(value = "mosip.certify.integration.vci-plugin", havingValue = "IdaVCIssuancePluginImpl")
+@ConditionalOnProperty(value = "mosip.certify.integration.data-provider-plugin", havingValue = "IdaDataProviderPluginImpl")
 public class AuthTransactionHelper {
 	
     private static final String AUTH_TOKEN_CACHE = "authtokens";

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/TransactionHelper.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/TransactionHelper.java
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package io.mosip.certify.mosipid.integration.helper;
+
+import io.mosip.esignet.core.dto.OIDCTransaction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(value = "mosip.certify.integration.data-provider-plugin", havingValue = "IdaDataProviderPluginImpl")
+public class TransactionHelper {
+
+    @Autowired
+    CacheManager cacheManager;
+
+    @Value("${mosip.certify.ida.vci-user-info-cache}")
+    private String userinfoCache;
+
+    @SuppressWarnings("unchecked")
+    public OIDCTransaction getOAuthTransaction(String accessTokenHash) throws Exception {
+        if (cacheManager.getCache(userinfoCache) != null) {
+            return cacheManager.getCache(userinfoCache).get(accessTokenHash, OIDCTransaction.class);	//NOSONAR getCache() will not be returning null here.
+        }
+        throw new Exception("cache_missing");
+    }
+
+}

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/VCIAuthTransactionHelper.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/VCIAuthTransactionHelper.java
@@ -1,0 +1,81 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package io.mosip.certify.mosipid.integration.helper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mosip.certify.mosipid.integration.dto.ClientIdSecretKeyRequest;
+import io.mosip.kernel.core.http.RequestWrapper;
+import io.mosip.kernel.core.http.ResponseWrapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDateTime;
+
+@Component
+@Slf4j
+@ConditionalOnProperty(value = "mosip.certify.integration.vci-plugin", havingValue = "IdaVCIssuancePluginImpl")
+@Deprecated
+public class VCIAuthTransactionHelper {
+
+    private static final String AUTH_TOKEN_CACHE = "authtokens";
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${mosip.certify.authenticator.ida.auth-token-url}")
+    private String authTokenUrl;
+
+    @Value("${mosip.certify.authenticator.ida.client-id}")
+    private String clientId;
+
+    @Value("${mosip.certify.authenticator.ida.secret-key}")
+    private String secretKey;
+
+    @Value("${mosip.certify.authenticator.ida.app-id}")
+    private String appId;
+
+    @Cacheable(value = AUTH_TOKEN_CACHE, key = "#root.target.AUTH_TOKEN_CACHE_KEY")
+    public String getAuthToken() throws Exception {
+        log.info("Started to get auth-token with appId : {} && clientId : {}",
+                appId, clientId);
+
+        RequestWrapper<ClientIdSecretKeyRequest> authRequest = new RequestWrapper<>();
+        authRequest.setRequesttime(LocalDateTime.now());
+        ClientIdSecretKeyRequest clientIdSecretKeyRequest = new ClientIdSecretKeyRequest(clientId, secretKey, appId);
+        authRequest.setRequest(clientIdSecretKeyRequest);
+
+        String requestBody = objectMapper.writeValueAsString(authRequest);
+        RequestEntity requestEntity = RequestEntity
+                .post(UriComponentsBuilder.fromUriString(authTokenUrl).build().toUri())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(requestBody);
+        ResponseEntity<ResponseWrapper> responseEntity = restTemplate.exchange(requestEntity,
+                new ParameterizedTypeReference<ResponseWrapper>() {});
+
+        String authToken = responseEntity.getHeaders().getFirst("authorization");
+        return authToken;
+    }
+
+    @CacheEvict(value = AUTH_TOKEN_CACHE, allEntries = true)
+    public void purgeAuthTokenCache() {
+        log.info("Evicting entry from AUTH_TOKEN_CACHE");
+    }
+
+}

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/VCITransactionHelper.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/VCITransactionHelper.java
@@ -13,7 +13,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnProperty(value = "mosip.certify.integration.vci-plugin", havingValue = "IdaVCIssuancePluginImpl")
+@ConditionalOnProperty(value = "mosip.certify.integration.data-provider-plugin", havingValue = "IdaDataProviderPluginImpl")
 public class VCITransactionHelper {
 
 	@Autowired

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/VCITransactionHelper.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/helper/VCITransactionHelper.java
@@ -13,7 +13,8 @@ import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
 @Component
-@ConditionalOnProperty(value = "mosip.certify.integration.data-provider-plugin", havingValue = "IdaDataProviderPluginImpl")
+@ConditionalOnProperty(value = "mosip.certify.integration.vci-plugin", havingValue = "IdaVCIssuancePluginImpl")
+@Deprecated
 public class VCITransactionHelper {
 
 	@Autowired

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/HelperService.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/HelperService.java
@@ -13,17 +13,20 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
 import java.nio.charset.StandardCharsets;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
+import java.util.*;
+import java.util.stream.Collectors;
 
 
 @Service
 @Slf4j
-@ConditionalOnProperty(value = "mosip.certify.integration.vci-plugin", havingValue = "IdaVCIssuancePluginImpl")
+@ConditionalOnProperty(value = "mosip.certify.integration.data-provider-plugin", havingValue = "IdaDataProviderPluginImpl")
 public class HelperService {
 
     public static final String UTC_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
@@ -42,7 +45,7 @@ public class HelperService {
         JWTSignatureRequestDto jwtSignatureRequestDto = new JWTSignatureRequestDto();
         jwtSignatureRequestDto.setApplicationId(OIDC_PARTNER_APP_ID);
         jwtSignatureRequestDto.setReferenceId("");
-        jwtSignatureRequestDto.setIncludePayload(false);
+        jwtSignatureRequestDto.setIncludePayload(true);
         jwtSignatureRequestDto.setIncludeCertificate(true);
         jwtSignatureRequestDto.setDataToSign(HelperService.b64Encode(request));
         JWTSignatureResponseDto responseDto = signatureService.jwtSign(jwtSignatureRequestDto);
@@ -60,4 +63,18 @@ public class HelperService {
         return urlSafeEncoder.encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 
+    //Converts an array of two-letter language codes to their corresponding ISO 639-2/T language codes.
+    protected List<String> convertLangCodesToISO3LanguageCodes(String[] langCodes) {
+        if(langCodes == null || langCodes.length == 0)
+            return List.of();
+        return Arrays.stream(langCodes)
+                .map(langCode -> {
+                    try {
+                        return StringUtils.isEmpty(langCode) ? null : new Locale(langCode).getISO3Language();
+                    } catch (MissingResourceException ex) {}
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
 }

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
@@ -1,13 +1,11 @@
 package io.mosip.certify.mosipid.integration.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.certify.api.exception.DataProviderExchangeException;
 import io.mosip.certify.api.spi.DataProviderPlugin;
 import io.mosip.certify.mosipid.integration.dto.*;
-import io.mosip.certify.mosipid.integration.helper.VCITransactionHelper;
+import io.mosip.certify.mosipid.integration.helper.TransactionHelper;
 import io.mosip.esignet.api.dto.*;
 import io.mosip.esignet.api.exception.KycExchangeException;
 import io.mosip.esignet.core.dto.OIDCTransaction;
@@ -15,7 +13,6 @@ import io.mosip.kernel.core.keymanager.spi.KeyStore;
 import io.mosip.kernel.keymanagerservice.constant.KeymanagerConstant;
 import io.mosip.kernel.keymanagerservice.entity.KeyAlias;
 import io.mosip.kernel.keymanagerservice.helper.KeymanagerDBHelper;
-import jakarta.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,8 +33,6 @@ import java.security.Key;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-
-import static io.mosip.esignet.core.constants.Constants.VERIFIED_CLAIMS;
 
 @Component
 @Slf4j
@@ -62,9 +57,6 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
     @Value("${mosip.certify.ida.kyc-exchange-id:mosip.identity.kycexchange}")
     private String kycExchangeId;
 
-    @Value("${mosip.certify.ida.vci-exchange-version}")
-    private String vciExchangeVersion;
-
     @Value("${mosip.certify.cache.secure.individual-id}")
     private boolean secureIndividualId;
 
@@ -76,9 +68,6 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
 
     @Value("${mosip.certify.cache.security.secretkey.reference-id}")
     private String cacheSecretKeyRefId;
-
-    @Value("${mosip.certify.authenticator.ida.secret-key}")
-    private String secretKey;
 
     @Value("#{'${mosip.certify.ida.kyc-exchange.accepted-claims}'.split(',')}")
     private List<String> kycExchangeAcceptedClaims;
@@ -102,7 +91,7 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
     private KeymanagerDBHelper dbHelper;
 
     @Autowired
-    VCITransactionHelper vciTransactionHelper;
+    TransactionHelper transactionHelper;
 
     private Base64.Decoder urlSafeDecoder = Base64.getUrlDecoder();
 
@@ -140,7 +129,7 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
         kycExchangeDto.setClaimsLocales(kycAcceptedLocales);
         kycExchangeDto.setUserInfoResponseType(null);
 
-        log.info("KYC exchange DTO built: {}", kycExchangeDto);
+        log.info("Built the KYC exchange DTO");
 
         return kycExchangeDto;
     }
@@ -188,15 +177,15 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
 
     public KycExchangeResult doKycExchange(Map<String, Object> identityDetails)
             throws Exception {
-        OIDCTransaction transaction = vciTransactionHelper
+        OIDCTransaction transaction = transactionHelper
                 .getOAuthTransaction(identityDetails.get(ACCESS_TOKEN_HASH).toString());
         KycExchangeDto kycExchangeDto = buildKycExchangeDto(transaction);
         String relyingPartyId = transaction.getRelyingPartyId();
         String clientId = transaction.getClientId();
-        return kycExchange(relyingPartyId, clientId, kycExchangeDto, false);
+        return kycExchange(relyingPartyId, clientId, kycExchangeDto);
     }
 
-    private KycExchangeResult kycExchange(String relyingPartyId, String clientId, KycExchangeDto kycExchangeDto,boolean isV2)
+    private KycExchangeResult kycExchange(String relyingPartyId, String clientId, KycExchangeDto kycExchangeDto)
             throws KycExchangeException {
         log.info("Started to build kyc-exchange request with transactionId : {} && clientId : {}",
                 kycExchangeDto.getTransactionId(), clientId);
@@ -209,14 +198,10 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
             idaKycExchangeRequest.setKycToken(kycExchangeDto.getKycToken());
             idaKycExchangeRequest.setConsentObtained(kycExchangeDto.getAcceptedClaims());
             idaKycExchangeRequest.setLocales(helperService.convertLangCodesToISO3LanguageCodes(kycExchangeDto.getClaimsLocales()));
-            idaKycExchangeRequest.setRespType(kycExchangeDto.getUserInfoResponseType()); //may be either JWT or JWE
+            idaKycExchangeRequest.setRespType(kycExchangeDto.getUserInfoResponseType()); // Setting the Response Type to null will give the final result as a JWT
             idaKycExchangeRequest.setIndividualId(kycExchangeDto.getIndividualId());
 
-            if(isV2){
-                setClaims((VerifiedKycExchangeDto) kycExchangeDto, idaKycExchangeRequest);
-            }
-
-            log.info("Sending the kyc exchange request : {}", idaKycExchangeRequest);
+            log.info("Built the kyc exchange request");
 
             //set signature header, body and invoke kyc exchange endpoint
             String requestBody = objectMapper.writeValueAsString(idaKycExchangeRequest);
@@ -247,46 +232,11 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
         throw new KycExchangeException();
     }
 
-    /**
-     * Set the verified and unVerified consented claims to {@link IdaKycExchangeRequest} object
-     * @param kycExchangeDto {@link KycExchangeDto}
-     * @param idaKycExchangeRequest {@link IdaKycExchangeRequest}
-     */
-    private void setClaims(VerifiedKycExchangeDto kycExchangeDto, IdaKycExchangeRequest idaKycExchangeRequest) {
-        if(kycExchangeDto != null){
-            Map<String, JsonNode> acceptedClaimDetails = kycExchangeDto.getAcceptedClaimDetails();
-            if(acceptedClaimDetails!=null && acceptedClaimDetails.get(VERIFIED_CLAIMS)!=null){
-                List<Map<String, Object>> verifiedClaimsList = objectMapper.convertValue(kycExchangeDto.getAcceptedClaimDetails()
-                        .get(VERIFIED_CLAIMS), new TypeReference<>() {});
-                idaKycExchangeRequest.setVerifiedConsentedClaims(verifiedClaimsList);
-            }
-
-            idaKycExchangeRequest.setUnVerifiedConsentedClaims(getUnVerifiedConsentedClaims(acceptedClaimDetails));
-        }
-    }
-
-    /**
-     * Method to return un verified consented claims
-     * @param acceptedClaimDetails Accepted claims Map
-     * @return un verified consented claims
-     */
-    @NotNull // This is added to not return null either return un verified claims map or empty map
-    private Map<String, Object> getUnVerifiedConsentedClaims(Map<String, JsonNode> acceptedClaimDetails) {
-        Map<String, JsonNode> unVerifiedConsentedClaims = new HashMap<>();
-        if(!CollectionUtils.isEmpty(acceptedClaimDetails)) {
-            for(Map.Entry<String, JsonNode> entry : acceptedClaimDetails.entrySet()) {
-                String key = entry.getKey();
-                JsonNode value = entry.getValue();
-                if(!key.equals(VERIFIED_CLAIMS)){
-                    unVerifiedConsentedClaims.put(key,value);
-                }
-            }
-        }
-        return objectMapper.convertValue(unVerifiedConsentedClaims, new TypeReference<>() {});
-    }
-
-    private Map<String, Object> decodeClaimsFromJwt(String jwtToken) throws JsonProcessingException {
+    private Map<String, Object> decodeClaimsFromJwt(String jwtToken) throws JsonProcessingException, DataProviderExchangeException {
         String[] parts = jwtToken.split("\\.");
+        if(parts.length < 3) {
+            throw new DataProviderExchangeException("Invalid KYC Exchange response.");
+        }
         String payload = new String(urlSafeDecoder.decode(parts[1]));
         Map<String, Object> claims = objectMapper.readValue(payload, Map.class);
 

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
@@ -1,0 +1,291 @@
+package io.mosip.certify.mosipid.integration.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.mosip.certify.api.exception.DataProviderExchangeException;
+import io.mosip.certify.api.spi.DataProviderPlugin;
+import io.mosip.certify.mosipid.integration.dto.*;
+import io.mosip.certify.mosipid.integration.helper.VCITransactionHelper;
+import io.mosip.esignet.api.dto.*;
+import io.mosip.esignet.api.exception.KycExchangeException;
+import io.mosip.esignet.core.dto.OIDCTransaction;
+import io.mosip.kernel.core.keymanager.spi.KeyStore;
+import io.mosip.kernel.keymanagerservice.constant.KeymanagerConstant;
+import io.mosip.kernel.keymanagerservice.entity.KeyAlias;
+import io.mosip.kernel.keymanagerservice.helper.KeymanagerDBHelper;
+import jakarta.validation.constraints.NotNull;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.crypto.Cipher;
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+import static io.mosip.esignet.core.constants.Constants.VERIFIED_CLAIMS;
+
+@Component
+@Slf4j
+@ConditionalOnProperty(value = "mosip.certify.integration.data-provider-plugin", havingValue = "IdaDataProviderPluginImpl")
+public class IdaDataProviderPluginImpl implements DataProviderPlugin {
+    // TODO: Clean up code
+    // TODO: Write unit tests
+
+    private static final String ACCESS_TOKEN_HASH = "accessTokenHash";
+    public static final String SIGNATURE_HEADER_NAME = "signature";
+    public static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+    public static final String OIDC_SERVICE_APP_ID = "CERTIFY_SERVICE";
+    public static final String AES_CIPHER_FAILED = "aes_cipher_failed";
+    public static final String NO_UNIQUE_ALIAS = "no_unique_alias";
+
+    @Value("${mosip.certify.authenticator.ida-version:1.0}")
+    private String idaVersion;
+
+    @Value("${mosip.certify.authenticator.ida.kyc-exchange-url}")
+    private String kycExchangeUrl;
+
+    @Value("${mosip.certify.ida.kyc-exchange-id:mosip.identity.kycexchange}")
+    private String kycExchangeId;
+
+    @Value("${mosip.certify.ida.vci-exchange-version}")
+    private String vciExchangeVersion;
+
+    @Value("${mosip.certify.cache.secure.individual-id}")
+    private boolean secureIndividualId;
+
+    @Value("${mosip.certify.cache.store.individual-id}")
+    private boolean storeIndividualId;
+
+    @Value("${mosip.certify.cache.security.algorithm-name}")
+    private String aesECBTransformation;
+
+    @Value("${mosip.certify.cache.security.secretkey.reference-id}")
+    private String cacheSecretKeyRefId;
+
+    @Value("${mosip.certify.authenticator.ida.secret-key}")
+    private String secretKey;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Autowired
+    HelperService helperService;
+
+    @Autowired
+    private KeyStore keyStore;
+
+    @Autowired
+    private KeymanagerDBHelper dbHelper;
+
+    @Autowired
+    VCITransactionHelper vciTransactionHelper;
+
+    private Base64.Decoder urlSafeDecoder = Base64.getUrlDecoder();
+
+    @Override
+    public JSONObject fetchData(Map<String, Object> identityDetails) throws DataProviderExchangeException {
+        try {
+            KycExchangeResult kycExchangeResult = doKycExchange(identityDetails);
+            if(kycExchangeResult != null) {
+                String encryptedKyc = kycExchangeResult.getEncryptedKyc();
+                log.info("Kyc exchange result: {}", kycExchangeResult.getEncryptedKyc());
+                Map<String, Object> claims = decodeClaimsFromJwt(encryptedKyc);
+                log.info("Jwt Claims: {}", claims);
+
+                return new JSONObject(claims);
+            }
+        }
+        catch (JSONException | JsonProcessingException e) {
+            log.error("Error occurred during json processing: " + e.getMessage());
+            throw new DataProviderExchangeException("JSON_PARSING_FAILED", e.getMessage());
+        }
+        catch (Exception e) {
+            log.error("ERROR_FETCHING_KYC_DATA. " +  e.getMessage());
+            throw new DataProviderExchangeException("ERROR_FETCHING_KYC_DATA", e.getMessage());
+        }
+        throw new DataProviderExchangeException("No data found for kyc exchange");
+    }
+
+    private KycExchangeDto buildKycExchangeDto(OIDCTransaction transaction) throws Exception {
+        KycExchangeDto kycExchangeDto = new KycExchangeDto();
+
+        String individualId = getIndividualId(transaction.getIndividualId());
+        kycExchangeDto.setIndividualId(individualId);
+        kycExchangeDto.setTransactionId(transaction.getAuthTransactionId());
+        kycExchangeDto.setKycToken(transaction.getKycToken());
+        // Todo: Take this list as config
+        kycExchangeDto.setAcceptedClaims(List.of("fullName", "dateOfBirth", "gender", "region", "city", "postalCode", "phoneNumber", "UIN", "VID"));
+        kycExchangeDto.setClaimsLocales(new String[]{"en"});
+        kycExchangeDto.setUserInfoResponseType(null);
+
+        log.info("KYC exchange DTO built: {}", kycExchangeDto);
+
+        return kycExchangeDto;
+    }
+
+    protected String getIndividualId(String encryptedIndividualId) throws Exception {
+        if (!storeIndividualId)
+            return null;
+        return secureIndividualId ? decryptIndividualId(encryptedIndividualId) : encryptedIndividualId;
+    }
+
+    private String decryptIndividualId(String encryptedIndividualId) throws Exception {
+        try {
+            Cipher cipher = Cipher.getInstance(aesECBTransformation);
+            byte[] decodedBytes = b64Decode(encryptedIndividualId);
+            cipher.init(Cipher.DECRYPT_MODE, getSecretKeyFromHSM());
+            return new String(cipher.doFinal(decodedBytes, 0, decodedBytes.length));
+        } catch (Exception e) {
+            log.error("Error Cipher Operations of provided secret data.", e);
+            throw new Exception(AES_CIPHER_FAILED);
+        }
+    }
+
+    private Key getSecretKeyFromHSM() throws Exception {
+        String keyAlias = getKeyAlias(OIDC_SERVICE_APP_ID, cacheSecretKeyRefId);
+        if (Objects.nonNull(keyAlias)) {
+            return keyStore.getSymmetricKey(keyAlias);
+        }
+        throw new Exception(NO_UNIQUE_ALIAS);
+    }
+
+    private String getKeyAlias(String keyAppId, String keyRefId) throws Exception {
+        Map<String, List<KeyAlias>> keyAliasMap = dbHelper.getKeyAliases(keyAppId, keyRefId,
+                LocalDateTime.now(ZoneOffset.UTC));
+        List<KeyAlias> currentKeyAliases = keyAliasMap.get(KeymanagerConstant.CURRENTKEYALIAS);
+        if (!currentKeyAliases.isEmpty() && currentKeyAliases.size() == 1) {
+            return currentKeyAliases.get(0).getAlias();
+        }
+        log.error("CurrentKeyAlias is not unique. KeyAlias count: {}", currentKeyAliases.size());
+        throw new Exception(NO_UNIQUE_ALIAS);
+    }
+
+    private byte[] b64Decode(String value) {
+        return urlSafeDecoder.decode(value);
+    };
+
+    public KycExchangeResult doKycExchange(Map<String, Object> identityDetails)
+            throws Exception {
+        OIDCTransaction transaction = vciTransactionHelper
+                .getOAuthTransaction(identityDetails.get(ACCESS_TOKEN_HASH).toString());
+        KycExchangeDto kycExchangeDto = buildKycExchangeDto(transaction);
+        String relyingPartyId = transaction.getRelyingPartyId();
+        String clientId = transaction.getClientId();
+        return kycExchange(relyingPartyId, clientId, kycExchangeDto, false);
+    }
+
+    private KycExchangeResult kycExchange(String relyingPartyId, String clientId, KycExchangeDto kycExchangeDto,boolean isV2)
+            throws KycExchangeException {
+        log.info("Started to build kyc-exchange request with transactionId : {} && clientId : {}",
+                kycExchangeDto.getTransactionId(), clientId);
+        try {
+            IdaKycExchangeRequest idaKycExchangeRequest = new IdaKycExchangeRequest();
+            idaKycExchangeRequest.setId(kycExchangeId);
+            idaKycExchangeRequest.setVersion(idaVersion);
+            idaKycExchangeRequest.setRequestTime(HelperService.getUTCDateTime());
+            idaKycExchangeRequest.setTransactionID(kycExchangeDto.getTransactionId());
+            idaKycExchangeRequest.setKycToken(kycExchangeDto.getKycToken());
+            idaKycExchangeRequest.setConsentObtained(kycExchangeDto.getAcceptedClaims());
+            idaKycExchangeRequest.setLocales(helperService.convertLangCodesToISO3LanguageCodes(kycExchangeDto.getClaimsLocales()));
+            idaKycExchangeRequest.setRespType(kycExchangeDto.getUserInfoResponseType()); //may be either JWT or JWE
+            idaKycExchangeRequest.setIndividualId(kycExchangeDto.getIndividualId());
+
+            if(isV2){
+                setClaims((VerifiedKycExchangeDto) kycExchangeDto, idaKycExchangeRequest);
+            }
+
+            log.info("Sending the kyc exchange request : {}", idaKycExchangeRequest);
+
+            //set signature header, body and invoke kyc exchange endpoint
+            String requestBody = objectMapper.writeValueAsString(idaKycExchangeRequest);
+            RequestEntity requestEntity = RequestEntity
+                    .post(UriComponentsBuilder.fromUriString(kycExchangeUrl).pathSegment(relyingPartyId,
+                            clientId).build().toUri())
+                    .contentType(MediaType.APPLICATION_JSON_UTF8)
+                    .header(SIGNATURE_HEADER_NAME, helperService.getRequestSignature(requestBody))
+                    .header(AUTHORIZATION_HEADER_NAME, AUTHORIZATION_HEADER_NAME)
+                    .body(requestBody);
+            ResponseEntity<IdaResponseWrapper<IdaKycExchangeResponse>> responseEntity = restTemplate.exchange(requestEntity,
+                    new ParameterizedTypeReference<IdaResponseWrapper<IdaKycExchangeResponse>>() {});
+
+            if(responseEntity.getStatusCode().is2xxSuccessful() && responseEntity.getBody() != null) {
+                IdaResponseWrapper<IdaKycExchangeResponse> responseWrapper = responseEntity.getBody();
+                if(responseWrapper.getResponse() != null && responseWrapper.getResponse().getEncryptedKyc() != null) {
+                    return new KycExchangeResult(responseWrapper.getResponse().getEncryptedKyc());
+                }
+                log.error("Errors in response received from IDA Kyc Exchange: {}", responseWrapper.getErrors());
+                throw new KycExchangeException(CollectionUtils.isEmpty(responseWrapper.getErrors()) ?
+                        io.mosip.esignet.api.util.ErrorConstants.DATA_EXCHANGE_FAILED : responseWrapper.getErrors().get(0).getErrorCode());
+            }
+
+            log.error("Error response received from IDA (Kyc-exchange) with status : {}", responseEntity.getStatusCode());
+        } catch (KycExchangeException e) { throw e; } catch (Exception e) {
+            log.error("IDA Kyc-exchange failed with clientId : {}", clientId, e);
+        }
+        throw new KycExchangeException();
+    }
+
+    /**
+     * Set the verfied and unVerified consented claims to {@link IdaKycExchangeRequest} object
+     * @param kycExchangeDto {@link KycExchangeDto}
+     * @param idaKycExchangeRequest {@link IdaKycExchangeRequest}
+     */
+    private void setClaims(VerifiedKycExchangeDto kycExchangeDto, IdaKycExchangeRequest idaKycExchangeRequest) {
+        if(kycExchangeDto != null){
+            Map<String, JsonNode> acceptedClaimDetails = kycExchangeDto.getAcceptedClaimDetails();
+            if(acceptedClaimDetails!=null && acceptedClaimDetails.get(VERIFIED_CLAIMS)!=null){
+                List<Map<String, Object>> verifiedClaimsList = objectMapper.convertValue(kycExchangeDto.getAcceptedClaimDetails()
+                        .get(VERIFIED_CLAIMS), new TypeReference<>() {});
+                idaKycExchangeRequest.setVerifiedConsentedClaims(verifiedClaimsList);
+            }
+
+            idaKycExchangeRequest.setUnVerifiedConsentedClaims(getUnVerifiedConsentedClaims(acceptedClaimDetails));
+        }
+    }
+
+    /**
+     * Method to return un verified consented claims
+     * @param acceptedClaimDetails Accepted claims Map
+     * @return un verified consented claims
+     */
+    @NotNull // This is added to not return null either return un verified claims map or empty map
+    private Map<String, Object> getUnVerifiedConsentedClaims(Map<String, JsonNode> acceptedClaimDetails) {
+        Map<String, JsonNode> unVerifiedConsentedClaims = new HashMap<>();
+        if(!CollectionUtils.isEmpty(acceptedClaimDetails)) {
+            for(Map.Entry<String, JsonNode> entry : acceptedClaimDetails.entrySet()) {
+                String key = entry.getKey();
+                JsonNode value = entry.getValue();
+                if(!key.equals(VERIFIED_CLAIMS)){
+                    unVerifiedConsentedClaims.put(key,value);
+                }
+            }
+        }
+        return objectMapper.convertValue(unVerifiedConsentedClaims, new TypeReference<>() {});
+    }
+
+    private Map<String, Object> decodeClaimsFromJwt(String jwtToken) throws JsonProcessingException {
+        String[] parts = jwtToken.split("\\.");
+        String payload = new String(urlSafeDecoder.decode(parts[1]));
+        Map<String, Object> claims = objectMapper.readValue(payload, Map.class);
+
+        return claims;
+    }
+}

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
@@ -83,6 +83,9 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
     @Value("#{'${mosip.certify.ida.kyc-exchange.accepted-claims}'.split(',')}")
     private List<String> kycExchangeAcceptedClaims;
 
+    @Value("${mosip.certify.ida.kyc-exchange.accepted-locales:en}")
+    private String[] kycAcceptedLocales;
+
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -108,10 +111,9 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
         try {
             KycExchangeResult kycExchangeResult = doKycExchange(identityDetails);
             if(kycExchangeResult != null) {
+                log.info("Kyc Exchange Success.");
                 String encryptedKyc = kycExchangeResult.getEncryptedKyc();
-                log.info("Kyc exchange result: {}", kycExchangeResult.getEncryptedKyc());
                 Map<String, Object> claims = decodeClaimsFromJwt(encryptedKyc);
-                log.info("Jwt Claims: {}", claims);
 
                 return new JSONObject(claims);
             }
@@ -124,7 +126,7 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
             log.error("ERROR_FETCHING_KYC_DATA. " +  e.getMessage());
             throw new DataProviderExchangeException("ERROR_FETCHING_KYC_DATA", e.getMessage());
         }
-        throw new DataProviderExchangeException("No data found for kyc exchange");
+        throw new DataProviderExchangeException("ERROR_FETCHING_KYC_DATA", "No data found for kyc exchange");
     }
 
     private KycExchangeDto buildKycExchangeDto(OIDCTransaction transaction) throws Exception {
@@ -134,9 +136,8 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
         kycExchangeDto.setIndividualId(individualId);
         kycExchangeDto.setTransactionId(transaction.getAuthTransactionId());
         kycExchangeDto.setKycToken(transaction.getKycToken());
-        // Todo: Take this list as config
         kycExchangeDto.setAcceptedClaims(kycExchangeAcceptedClaims);
-        kycExchangeDto.setClaimsLocales(new String[]{"en"});
+        kycExchangeDto.setClaimsLocales(kycAcceptedLocales);
         kycExchangeDto.setUserInfoResponseType(null);
 
         log.info("KYC exchange DTO built: {}", kycExchangeDto);

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
@@ -248,7 +248,7 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
     }
 
     /**
-     * Set the verfied and unVerified consented claims to {@link IdaKycExchangeRequest} object
+     * Set the verified and unVerified consented claims to {@link IdaKycExchangeRequest} object
      * @param kycExchangeDto {@link KycExchangeDto}
      * @param idaKycExchangeRequest {@link IdaKycExchangeRequest}
      */

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaDataProviderPluginImpl.java
@@ -80,6 +80,9 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
     @Value("${mosip.certify.authenticator.ida.secret-key}")
     private String secretKey;
 
+    @Value("#{'${mosip.certify.ida.kyc-exchange.accepted-claims}'.split(',')}")
+    private List<String> kycExchangeAcceptedClaims;
+
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -132,7 +135,7 @@ public class IdaDataProviderPluginImpl implements DataProviderPlugin {
         kycExchangeDto.setTransactionId(transaction.getAuthTransactionId());
         kycExchangeDto.setKycToken(transaction.getKycToken());
         // Todo: Take this list as config
-        kycExchangeDto.setAcceptedClaims(List.of("fullName", "dateOfBirth", "gender", "region", "city", "postalCode", "phoneNumber", "UIN", "VID"));
+        kycExchangeDto.setAcceptedClaims(kycExchangeAcceptedClaims);
         kycExchangeDto.setClaimsLocales(new String[]{"en"});
         kycExchangeDto.setUserInfoResponseType(null);
 

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaVCIssuancePluginImpl.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/IdaVCIssuancePluginImpl.java
@@ -48,6 +48,7 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @Slf4j
 @ConditionalOnProperty(value = "mosip.certify.integration.vci-plugin", havingValue = "IdaVCIssuancePluginImpl")
+@Deprecated
 public class IdaVCIssuancePluginImpl implements VCIssuancePlugin {
 	private static final String CLIENT_ID = "client_id";
 	private static final String ACCESS_TOKEN_HASH = "accessTokenHash";
@@ -64,7 +65,7 @@ public class IdaVCIssuancePluginImpl implements VCIssuancePlugin {
 	private RestTemplate restTemplate;
 
 	@Autowired
-	HelperService helperService;
+	VCIHelperService helperService;
 
 	@Autowired
 	private KeyStore keyStore;

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/VCIHelperService.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/VCIHelperService.java
@@ -1,0 +1,81 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+package io.mosip.certify.mosipid.integration.service;
+
+
+import io.mosip.kernel.signature.dto.JWTSignatureRequestDto;
+import io.mosip.kernel.signature.dto.JWTSignatureResponseDto;
+import io.mosip.kernel.signature.service.SignatureService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+@Service
+@Slf4j
+@ConditionalOnProperty(value = "mosip.certify.integration.vci-plugin", havingValue = "IdaVCIssuancePluginImpl")
+@Deprecated
+public class VCIHelperService {
+
+    public static final String UTC_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static final String OIDC_PARTNER_APP_ID = "CERTIFY_PARTNER";
+    private static Base64.Encoder urlSafeEncoder;
+
+    static {
+        urlSafeEncoder = Base64.getUrlEncoder().withoutPadding();
+    }
+
+
+    @Autowired
+    private SignatureService signatureService;
+
+    protected String getRequestSignature(String request) {
+        JWTSignatureRequestDto jwtSignatureRequestDto = new JWTSignatureRequestDto();
+        jwtSignatureRequestDto.setApplicationId(OIDC_PARTNER_APP_ID);
+        jwtSignatureRequestDto.setReferenceId("");
+        jwtSignatureRequestDto.setIncludePayload(true);
+        jwtSignatureRequestDto.setIncludeCertificate(true);
+        jwtSignatureRequestDto.setDataToSign(HelperService.b64Encode(request));
+        JWTSignatureResponseDto responseDto = signatureService.jwtSign(jwtSignatureRequestDto);
+        log.debug("Request signature ---> {}", responseDto.getJwtSignedData());
+        return responseDto.getJwtSignedData();
+    }
+
+    protected static String getUTCDateTime() {
+        return ZonedDateTime
+                .now(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ofPattern(UTC_DATETIME_PATTERN));
+    }
+
+    protected static String b64Encode(String value) {
+        return urlSafeEncoder.encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    //Converts an array of two-letter language codes to their corresponding ISO 639-2/T language codes.
+    protected List<String> convertLangCodesToISO3LanguageCodes(String[] langCodes) {
+        if(langCodes == null || langCodes.length == 0)
+            return List.of();
+        return Arrays.stream(langCodes)
+                .map(langCode -> {
+                    try {
+                        return StringUtils.isEmpty(langCode) ? null : new Locale(langCode).getISO3Language();
+                    } catch (MissingResourceException ex) {}
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+}

--- a/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/VCIHelperService.java
+++ b/mosip-identity-certify-plugin/src/main/java/io/mosip/certify/mosipid/integration/service/VCIHelperService.java
@@ -46,7 +46,7 @@ public class VCIHelperService {
         JWTSignatureRequestDto jwtSignatureRequestDto = new JWTSignatureRequestDto();
         jwtSignatureRequestDto.setApplicationId(OIDC_PARTNER_APP_ID);
         jwtSignatureRequestDto.setReferenceId("");
-        jwtSignatureRequestDto.setIncludePayload(true);
+        jwtSignatureRequestDto.setIncludePayload(false);
         jwtSignatureRequestDto.setIncludeCertificate(true);
         jwtSignatureRequestDto.setDataToSign(HelperService.b64Encode(request));
         JWTSignatureResponseDto responseDto = signatureService.jwtSign(jwtSignatureRequestDto);
@@ -62,20 +62,5 @@ public class VCIHelperService {
 
     protected static String b64Encode(String value) {
         return urlSafeEncoder.encodeToString(value.getBytes(StandardCharsets.UTF_8));
-    }
-
-    //Converts an array of two-letter language codes to their corresponding ISO 639-2/T language codes.
-    protected List<String> convertLangCodesToISO3LanguageCodes(String[] langCodes) {
-        if(langCodes == null || langCodes.length == 0)
-            return List.of();
-        return Arrays.stream(langCodes)
-                .map(langCode -> {
-                    try {
-                        return StringUtils.isEmpty(langCode) ? null : new Locale(langCode).getISO3Language();
-                    } catch (MissingResourceException ex) {}
-                    return null;
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
     }
 }

--- a/mosip-identity-certify-plugin/src/test/java/io/mosip/certify/mosipid/integration/service/IdaVCIssuancePluginImplTest.java
+++ b/mosip-identity-certify-plugin/src/test/java/io/mosip/certify/mosipid/integration/service/IdaVCIssuancePluginImplTest.java
@@ -58,7 +58,7 @@ public class IdaVCIssuancePluginImplTest {
     RestTemplate restTemplate;
 
     @Mock
-    HelperService helperService;
+    VCIHelperService helperService;
 
     @Mock
     KeymanagerDBHelper keymanagerDBHelper;

--- a/postgres-dataprovider-plugin/pom.xml
+++ b/postgres-dataprovider-plugin/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.inji.certify</groupId>
     <artifactId>postgres-dataprovider-plugin</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>postgres-dataprovider-plugin</name>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>io.mosip.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>0.12.0-SNAPSHOT</version>
+            <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/postgres-dataprovider-plugin/pom.xml
+++ b/postgres-dataprovider-plugin/pom.xml
@@ -56,7 +56,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.mosip.certify</groupId>
+            <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
             <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>

--- a/sunbird-rc-certify-integration-impl/pom.xml
+++ b/sunbird-rc-certify-integration-impl/pom.xml
@@ -52,7 +52,7 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>io.mosip.certify</groupId>
+            <groupId>io.inji.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
             <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>

--- a/sunbird-rc-certify-integration-impl/pom.xml
+++ b/sunbird-rc-certify-integration-impl/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji.certify.sunbirdrc</groupId>
     <artifactId>sunbird-rc-certify-integration-impl</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sunbird-rc-certify-integration-impl</name>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>io.mosip.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
-            <version>0.12.0-SNAPSHOT</version>
+            <version>0.14.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped project versions to 0.6.0-SNAPSHOT and upgraded core dependencies (certify, esignet) to new groupIds/versions; added Jackson annotations dependency.

* **New Features**
  * Added an IDA-based data provider plugin for KYC exchange with encrypted-identifier handling, signed requests, claim mapping, and language-code conversion.
  * Added DTOs for KYC request/response and helpers for OAuth transaction caching and auth-token management.

* **Bug Fixes / Behavior**
  * Updated conditional activation to new configuration properties.

* **Deprecated**
  * Marked several VCI-related helpers and plugin classes as deprecated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->