### PR TITLE
Update pom versions to 1.0.0-alpha.1-SNAPSHOT

### DIFF
--- a/mock-certify-plugin/pom.xml
+++ b/mock-certify-plugin/pom.xml
@@ -10,7 +10,7 @@
 
       <groupId>io.inji.certify</groupId>
       <artifactId>mock-certify-plugin</artifactId>
-      <version>0.7.0-SNAPSHOT</version>
+      <version>1.0.0-SNAPSHOT</version>
       <packaging>jar</packaging>
 
       <name>mock-certify-integration-impl</name>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>0.14.0-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/mock-certify-plugin/pom.xml
+++ b/mock-certify-plugin/pom.xml
@@ -10,7 +10,7 @@
 
       <groupId>io.inji.certify</groupId>
       <artifactId>mock-certify-plugin</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0.0-alpha.1-SNAPSHOT</version>
       <packaging>jar</packaging>
 
       <name>mock-certify-integration-impl</name>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji.certify</groupId>
     <artifactId>mosip-identity-certify-plugin</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-alpha.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>mosipid-certify-integration-impl</name>
@@ -98,13 +98,13 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji.certify</groupId>
     <artifactId>mosip-identity-certify-plugin</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>mosipid-certify-integration-impl</name>
@@ -98,13 +98,13 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>0.14.0-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
-            <version>0.14.0-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/postgres-dataprovider-plugin/pom.xml
+++ b/postgres-dataprovider-plugin/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.inji.certify</groupId>
     <artifactId>postgres-dataprovider-plugin</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-alpha.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>postgres-dataprovider-plugin</name>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/postgres-dataprovider-plugin/pom.xml
+++ b/postgres-dataprovider-plugin/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.inji.certify</groupId>
     <artifactId>postgres-dataprovider-plugin</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>postgres-dataprovider-plugin</name>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>0.14.0-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/sunbird-rc-certify-integration-impl/pom.xml
+++ b/sunbird-rc-certify-integration-impl/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji.certify.sunbirdrc</groupId>
     <artifactId>sunbird-rc-certify-integration-impl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-alpha.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sunbird-rc-certify-integration-impl</name>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/sunbird-rc-certify-integration-impl/pom.xml
+++ b/sunbird-rc-certify-integration-impl/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji.certify.sunbirdrc</groupId>
     <artifactId>sunbird-rc-certify-integration-impl</artifactId>
-    <version>0.7.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>sunbird-rc-certify-integration-impl</name>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
-            <version>0.14.0-SNAPSHOT</version>
+            <version>1.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several project and dependency versions to `1.0.0-alpha.1-SNAPSHOT` for consistency across the build.
  * Kept the release aligned with the newer alpha snapshot versions of the certification components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->