### PR TITLE
fix: resolve Sonar analysis failures (source/test overlap + missing plugin version)

### DIFF
--- a/mock-certify-plugin/pom.xml
+++ b/mock-certify-plugin/pom.xml
@@ -37,6 +37,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.exclusions>src/test/**</sonar.exclusions>
         <java.version>21</java.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -70,6 +70,7 @@
     </distributionManagement>
     <properties>
         <sonar.exclusions>src/test/**</sonar.exclusions>
+        <maven.sonar.version>3.11.0.3922</maven.sonar.version>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -69,6 +69,7 @@
         </repository>
     </distributionManagement>
     <properties>
+        <sonar.exclusions>src/test/**</sonar.exclusions>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/postgres-dataprovider-plugin/pom.xml
+++ b/postgres-dataprovider-plugin/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.exclusions>src/test/**</sonar.exclusions>
         <java.version>21</java.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/sunbird-rc-certify-integration-impl/pom.xml
+++ b/sunbird-rc-certify-integration-impl/pom.xml
@@ -34,6 +34,7 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.exclusions>src/test/**</sonar.exclusions>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
## Summary
- Add `sonar.exclusions=src/test/**` to all four plugin modules (`mock-certify-plugin`, `mosip-identity-certify-plugin`, `postgres-dataprovider-plugin`, `sunbird-rc-certify-integration-impl`) to fix SonarCloud's `can't be indexed twice` failure. The shared `maven-sonar-analysis.yml@v0.0.1` workflow's `settings.xml` activates a `sonar`-named profile that forces `sonar.sources=.`, causing `src/test/java` files to match both the main-source and test-source sets.
- Define the missing `maven.sonar.version` property in `mosip-identity-certify-plugin/pom.xml`, whose local `sonar` profile references `${maven.sonar.version}` for the `sonar-maven-plugin` version but never defined it. This profile was previously never activated by the older `maven-sonar-analysis-new.yml@develop` workflow, so the bug was dormant until the workflow reference was updated to `maven-sonar-analysis.yml@v0.0.1` in #186.

## Test plan
- [ ] Confirm the `sonar_analysis_*` jobs pass on this branch's CI run for all four modules
- [ ] Confirm coverage % is still reported correctly on SonarCloud (JaCoco report path unaffected by this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SonarQube analysis settings across several modules.
  * Test source files are now excluded from SonarQube analysis.
  * Added the configured Maven Sonar plugin version where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->