### PR TITLE
fix: resolve Sonar analysis failures (source/test overlap + missing plugin version) (#189)

### DIFF
--- a/mock-certify-plugin/pom.xml
+++ b/mock-certify-plugin/pom.xml
@@ -37,6 +37,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.exclusions>src/test/**</sonar.exclusions>
         <java.version>21</java.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -69,6 +69,8 @@
         </repository>
     </distributionManagement>
     <properties>
+        <sonar.exclusions>src/test/**</sonar.exclusions>
+        <maven.sonar.version>3.11.0.3922</maven.sonar.version>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>

--- a/postgres-dataprovider-plugin/pom.xml
+++ b/postgres-dataprovider-plugin/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.exclusions>src/test/**</sonar.exclusions>
         <java.version>21</java.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven.compiler.source>21</maven.compiler.source>

--- a/sunbird-rc-certify-integration-impl/pom.xml
+++ b/sunbird-rc-certify-integration-impl/pom.xml
@@ -34,6 +34,7 @@
     </developers>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.exclusions>src/test/**</sonar.exclusions>
         <java.version>21</java.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>


### PR DESCRIPTION
* fix: exclude test sources from Sonar main-source scan to prevent duplicate indexing

Sonar analysis failed with "can't be indexed twice" because the shared maven-sonar-analysis workflow's settings.xml activates a profile (sonar) that sets sonar.sources=., causing src/test/java files to match both the main-source and test-source sets. Adding sonar.exclusions=src/test/** removes them from the main-source set without affecting test analysis or coverage.



* fix: define missing maven.sonar.version property in mosip-identity-certify-plugin

The module's local 'sonar' profile references sonar-maven-plugin version via \${maven.sonar.version}, but the property was never defined, so Maven fails validating the plugin version once this profile is activated (-Psonar). Pin it to the current stable sonar-maven-plugin release.



---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality analysis settings across certification and data-provider components.
  * Excluded test sources from SonarQube analysis.
  * Standardized the configured Sonar Maven plugin version where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->