### PR TITLE
[DSD-10594] inji-certify 1.0.0-alpfa.1 release

### DIFF
--- a/mock-certify-plugin/pom.xml
+++ b/mock-certify-plugin/pom.xml
@@ -7,7 +7,7 @@
 
       <groupId>io.inji.certify</groupId>
       <artifactId>mock-certify-plugin</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0.0-alpha.1</version>
       <packaging>jar</packaging>
 
       <name>mock-certify-integration-impl</name>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/mosip-identity-certify-plugin/pom.xml
+++ b/mosip-identity-certify-plugin/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji.certify</groupId>
     <artifactId>mosip-identity-certify-plugin</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-alpha.1</version>
     <packaging>jar</packaging>
 
     <name>mosipid-certify-integration-impl</name>
@@ -97,13 +97,13 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/postgres-dataprovider-plugin/pom.xml
+++ b/postgres-dataprovider-plugin/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.inji.certify</groupId>
     <artifactId>postgres-dataprovider-plugin</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-alpha.1</version>
     <packaging>jar</packaging>
 
     <name>postgres-dataprovider-plugin</name>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-core</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/sunbird-rc-certify-integration-impl/pom.xml
+++ b/sunbird-rc-certify-integration-impl/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.inji.certify.sunbirdrc</groupId>
     <artifactId>sunbird-rc-certify-integration-impl</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-alpha.1</version>
     <packaging>jar</packaging>
 
     <name>sunbird-rc-certify-integration-impl</name>
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>io.inji.certify</groupId>
             <artifactId>certify-integration-api</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.0.0-alpha.1</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Updated the project components to the `1.0.0-alpha.1` release version.
  * Aligned supporting certification dependencies with the same alpha release.
  * Replaced snapshot references to provide consistent versioning across the available plugins and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->